### PR TITLE
Make pivot values work with most iterables

### DIFF
--- a/pandas/tools/pivot.py
+++ b/pandas/tools/pivot.py
@@ -89,8 +89,9 @@ def pivot_table(data, values=None, index=None, columns=None, aggfunc='mean',
 
     values_passed = values is not None
     if values_passed:
-        if isinstance(values, (list, tuple)):
+        if hasattr(values, '__iter__') and not isinstance(values, str):
             values_multi = True
+            values = list(values)
         else:
             values_multi = False
             values = [values]


### PR DESCRIPTION
Previously the values check for pivot tables was only looking for lists or tuples. This patch allows for any generators or other iterables (such as dict.keys() in python 3) to be passed as values. They will be converted to lists when they are identified as iterables, excluding strings. The performance hit from the extra list type assignment to iterables that are already lists or tuples should be minor.
